### PR TITLE
Added php7-iconv

### DIFF
--- a/build/Dockerfile-nginx
+++ b/build/Dockerfile-nginx
@@ -16,7 +16,7 @@ RUN apk --no-cache add tzdata && \
 
 RUN apk --no-cache add \
     php7 php7-opcache php7-fpm php7-cgi php7-ctype php7-json php7-dom php7-zip php7-zip php7-gd \
-    php7-curl php7-mbstring php7-redis php7-mcrypt php7-posix php7-pdo_mysql php7-tokenizer php7-simplexml php7-session \
+    php7-curl php7-mbstring php7-redis php7-mcrypt php7-iconv php7-posix php7-pdo_mysql php7-tokenizer php7-simplexml php7-session \
     php7-xml php7-sockets php7-openssl php7-fileinfo php7-ldap php7-exif php7-pcntl php7-xmlwriter php7-phar php7-zlib \
     php7-intl
 ADD etc/php.ini /etc/php7/php.ini


### PR DESCRIPTION
- When installing symfony/skeleton (composer create-project symfony/skeleton), it throws an exception about missing iconv extension.

````
Problem 1
    - The requested PHP extension ext-iconv * is missing from your system. Install or enable PHP's iconv extension.
````