### PR TITLE
Run all services on port 8080 for Google App Engine compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ You can use [PHP-PM](https://github.com/php-pm/php-pm) using Docker. We provide 
 
 ## Images
 
-- [`phppm/nginx`](https://hub.docker.com/r/phppm/nginx/): Contains php-pm and uses NGiNX as static file serving 
+- [`phppm/nginx`](https://hub.docker.com/r/phppm/nginx/): Contains php-pm and uses NGiNX as static file serving
 - [`phppm/standalone`](https://hub.docker.com/r/phppm/standalone/): Contains php-pm and uses php-pm's ability to serve static files (slower)
 - [`phppm/ppm`](https://hub.docker.com/r/phppm/ppm/): Just the php-pm binary as entry point
 
@@ -19,22 +19,22 @@ $ docker run -v `pwd`:/var/www/ phppm/ppm --help
 $ docker run -v `pwd`:/var/www/ phppm/ppm config --help
 
 # with nginx as static file server
-$ docker run -v `pwd`:/var/www -p 8080:80 phppm/nginx
+$ docker run -v `pwd`:/var/www -p 80:8080 phppm/nginx
 
 # with php-pm as static file server (dev only)
-$ docker run -v `pwd`:/var/www -p 8080:80 phppm/standalone
+$ docker run -v `pwd`:/var/www -p 80:8080 phppm/standalone
 
 # use `PPM_CONFIG` environment variable to choose a different ppm config file.
-$ docker run  -v `pwd`:/var/www -p 80:80 phppm/nginx -c ppm-prod.json
+$ docker run  -v `pwd`:/var/www -p 80:8080 phppm/nginx -c ppm-prod.json
 
 # enable file tracking, to automatically restart ppm when php source changed
-$ docker run -v `pwd`:/var/www -p 80:80 phppm/nginx --debug=1 --app-env=dev
+$ docker run -v `pwd`:/var/www -p 80:8080 phppm/nginx --debug=1 --app-env=dev
 
 # change static file directory. PPM_STATIC relative to mounted /var/www/.
-$ docker run -v `pwd`:/var/www -p 80:80 phppm/nginx --static-directory=web/
+$ docker run -v `pwd`:/var/www -p 80:8080 phppm/nginx --static-directory=web/
 
 # Use 16 threads/workers for PHP-PM.
-$ docker run -v `pwd`:/var/www -p 80:80 phppm/nginx --workers=16
+$ docker run -v `pwd`:/var/www -p 80:8080 phppm/nginx --workers=16
 ```
 
 Docker compose
@@ -49,12 +49,12 @@ services:
     volumes:
       - ./symfony-app/:/var/www
     ports:
-      - "80:80"
+      - "80:8080"
 ```
 
 ### Configuration
 
-You should configure PPM via the ppm.json in the root directory, which is within the container mounted to 
+You should configure PPM via the ppm.json in the root directory, which is within the container mounted to
 `/var/www/`. Alternatively, you can overwrite each option using the regular cli arguments.
 
 ```
@@ -62,9 +62,9 @@ You should configure PPM via the ppm.json in the root directory, which is within
 docker run -v `pwd`:/var/www phppm/ppm config --help
 
 # not persisting config changes
-docker run -v `pwd`:/var/www -p 80:80 phppm/nginx --help
-docker run -v `pwd`:/var/www -p 80:80 phppm/nginx --workers=1 --debug 1
-docker run -v `pwd`:/var/www -p 80:80 phppm/nginx --c prod-ppm.json
+docker run -v `pwd`:/var/www -p 80:8080 phppm/nginx --help
+docker run -v `pwd`:/var/www -p 80:8080 phppm/nginx --workers=1 --debug 1
+docker run -v `pwd`:/var/www -p 80:8080 phppm/nginx --c prod-ppm.json
 ```
 
 ## Build image with own tools/dependencies
@@ -79,7 +79,7 @@ FROM phppm/nginx:1.0
 RUN apk --no-cache add git
 RUN apk --no-cache add ca-certificates wget
 
-# whatever you need 
+# whatever you need
 ```
 
 ```

--- a/build/Dockerfile-nginx
+++ b/build/Dockerfile-nginx
@@ -2,6 +2,7 @@ FROM composer/composer:1.1 as composer
 
 ARG version=dev-master
 ARG http_version=dev-master
+
 RUN mkdir /ppm && cd /ppm && composer require php-pm/php-pm:${version} && composer require php-pm/httpkernel-adapter:${http_version}
 
 FROM alpine:3.7
@@ -27,7 +28,7 @@ RUN apk --no-cache add nginx
 ADD etc/nginx_default.conf /etc/nginx/sites-enabled/default
 ADD etc/nginx.conf /etc/nginx/nginx.conf
 
-EXPOSE 80
+EXPOSE 8080
 
 COPY --from=composer /ppm /ppm
 

--- a/build/Dockerfile-ppm
+++ b/build/Dockerfile-ppm
@@ -23,7 +23,7 @@ ADD etc/php.ini /etc/php7/php.ini
 
 RUN apk --no-cache add bash
 
-EXPOSE 80
+EXPOSE 8080
 
 COPY --from=composer /ppm /ppm
 

--- a/build/Dockerfile-standalone
+++ b/build/Dockerfile-standalone
@@ -23,7 +23,7 @@ ADD etc/php.ini /etc/php7/php.ini
 
 RUN apk --no-cache add bash
 
-EXPOSE 80
+EXPOSE 8080
 
 COPY --from=composer /ppm /ppm
 

--- a/build/etc/nginx_default.conf
+++ b/build/etc/nginx_default.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 8080;
     server_name _;
     root STATIC_DIRECTORY;
 
@@ -14,6 +14,6 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_pass http://127.0.0.1:8080;
+        proxy_pass http://127.0.0.1:8081;
     }
 }

--- a/build/run-nginx.sh
+++ b/build/run-nginx.sh
@@ -15,7 +15,7 @@ nginx
 
 mkdir -p /ppm/run
 chmod -R 777 /ppm/run
-ARGS='--port=8080 --socket-path=/ppm/run --pidfile=/ppm/ppm.pid'
+ARGS='--port=8081 --socket-path=/ppm/run --pidfile=/ppm/ppm.pid'
 
 # make sure static-directory is not served by php-pm
 ARGS="$ARGS --static-directory=''"

--- a/build/run-ppm.sh
+++ b/build/run-ppm.sh
@@ -2,4 +2,5 @@
 
 trapIt () { "$@"& pid="$!"; trap "kill -INT $pid" INT TERM; while kill -0 $pid > /dev/null 2>&1; do wait $pid; ec="$?"; done; exit $ec;};
 
-trapIt /ppm/vendor/bin/ppm --ansi "$@"
+ARGS='--port 8080'
+trapIt /ppm/vendor/bin/ppm start --ansi $@

--- a/build/run-standalone.sh
+++ b/build/run-standalone.sh
@@ -2,5 +2,5 @@
 
 trapIt () { "$@"& pid="$!"; trap "kill -INT $pid" INT TERM; while kill -0 $pid > /dev/null 2>&1; do wait $pid; ec="$?"; done; exit $ec;};
 
-ARGS='--port 80'
+ARGS='--port 8080'
 trapIt /ppm/vendor/bin/ppm start --ansi $ARGS  $@


### PR DESCRIPTION
After submitting https://github.com/php-pm/php-pm-docker/issues/13, I decided to write a quick PR that makes php-pm-docker listen on port 8080 by default. 

I also updated all the references in README.md.