### PR TITLE
[maintenance]Update Dockerfile-nginx to the PHP 8

### DIFF
--- a/build/Dockerfile-nginx
+++ b/build/Dockerfile-nginx
@@ -22,7 +22,7 @@ ADD etc/nginx.conf /etc/nginx/nginx.conf
 
 EXPOSE 80
 
-ARG PHP_PM_VERSION=2.4
+ARG PHP_PM_VERSION=dev-master
 ARG PHP_PM_HTTP_VERSION=dev-master
 
 WORKDIR /ppm

--- a/build/Dockerfile-nginx
+++ b/build/Dockerfile-nginx
@@ -22,14 +22,14 @@ ADD etc/nginx.conf /etc/nginx/nginx.conf
 
 EXPOSE 80
 
-ARG PHP_PM_VERSION=dev-master
+ARG PHP_PM_VERSION=2.4
 ARG PHP_PM_HTTP_VERSION=dev-master
 
 WORKDIR /ppm
 
 COPY --from=composer:2.3 /usr/bin/composer /usr/bin/composer
 
-RUN composer require php-pm/php-pm:${PHP_PM_VERSION} && composer require php-pm/httpkernel-adapter:${PHP_PM_HTTP_VERSION}
+RUN composer require php-pm/php-pm:${PHP_PM_VERSION} php-pm/httpkernel-adapter:${PHP_PM_HTTP_VERSION}
 
 WORKDIR /var/www
 

--- a/build/Dockerfile-nginx
+++ b/build/Dockerfile-nginx
@@ -1,10 +1,4 @@
-FROM composer:1.9 as composer
-
-ARG version=dev-master
-ARG http_version=dev-master
-RUN mkdir /ppm && cd /ppm && composer require php-pm/php-pm:${version} && composer require php-pm/httpkernel-adapter:${http_version}
-
-FROM alpine:3.11
+FROM alpine:3.15
 
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
@@ -15,21 +9,28 @@ RUN apk --no-cache add tzdata && \
     apk del tzdata
 
 RUN apk --no-cache add \
-    php7 php7-opcache php7-fpm php7-cgi php7-ctype php7-json php7-dom php7-zip php7-zip php7-gd \
-    php7-curl php7-mbstring php7-redis php7-mcrypt php7-iconv php7-posix php7-pdo_mysql php7-tokenizer php7-simplexml php7-session \
-    php7-xml php7-sockets php7-openssl php7-fileinfo php7-ldap php7-exif php7-pcntl php7-xmlwriter php7-phar php7-zlib \
-    php7-intl
-ADD etc/php.ini /etc/php7/php.ini
+    php8 php8-opcache php8-fpm php8-cgi php8-ctype php8-json php8-dom php8-zip php8-zip php8-gd \
+    php8-curl php8-mbstring php8-redis php8-iconv php8-posix php8-pdo_mysql php8-tokenizer php8-simplexml php8-session \
+    php8-xml php8-sockets php8-openssl php8-fileinfo php8-ldap php8-exif php8-pcntl php8-xmlwriter php8-phar php8-zlib \
+    php8-intl php8-pcntl
+ADD etc/php.ini /etc/php8/php.ini
+RUN ln -s /usr/bin/php8 /usr/bin/php
 
-RUN apk --no-cache add bash
-
-RUN apk --no-cache add nginx
+RUN apk --no-cache add nginx bash
 ADD etc/nginx_default.conf /etc/nginx/sites-enabled/default
 ADD etc/nginx.conf /etc/nginx/nginx.conf
 
 EXPOSE 80
 
-COPY --from=composer /ppm /ppm
+ARG PHP_PM_VERSION=dev-master
+ARG PHP_PM_HTTP_VERSION=dev-master
+ARG COMPOSER_VERSION=2.3
+
+WORKDIR /ppm
+
+COPY --from=composer:${COMPOSER_VERSION} /usr/bin/composer /usr/bin/composer
+
+RUN composer require php-pm/php-pm:${PHP_PM_VERSION} && composer require php-pm/httpkernel-adapter:${PHP_PM_HTTP_VERSION}
 
 WORKDIR /var/www
 

--- a/build/Dockerfile-nginx
+++ b/build/Dockerfile-nginx
@@ -24,11 +24,10 @@ EXPOSE 80
 
 ARG PHP_PM_VERSION=dev-master
 ARG PHP_PM_HTTP_VERSION=dev-master
-ARG COMPOSER_VERSION=2.3
 
 WORKDIR /ppm
 
-COPY --from=composer:${COMPOSER_VERSION} /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.3 /usr/bin/composer /usr/bin/composer
 
 RUN composer require php-pm/php-pm:${PHP_PM_VERSION} && composer require php-pm/httpkernel-adapter:${PHP_PM_HTTP_VERSION}
 


### PR DESCRIPTION
it's kinda time to upgrade the PHP-PM docker to PHP 8.0 and the latest PHP-PM version. I decided to not use Multi-Stage with the composer as the pcntl extension is required and ignoring platform requirements may result in future problems.

```
#17 1.099 Your requirements could not be resolved to an installable set of packages.
#17 1.099 
#17 1.099   Problem 1
#17 1.099     - Root composer.json requires php-pm/php-pm dev-master -> satisfiable by php-pm/php-pm[dev-master].
#17 1.099     - php-pm/php-pm dev-master requires ext-pcntl * -> it is missing from your system. Install or enable PHP's pcntl extension.
#17 1.099 
#17 1.099 To enable extensions, verify that they are enabled in your .ini files:
#17 1.099     - /usr/local/etc/php/php-cli.ini
#17 1.099     - /usr/local/etc/php/conf.d/docker-php-ext-bz2.ini
#17 1.099     - /usr/local/etc/php/conf.d/docker-php-ext-sodium.ini
#17 1.099     - /usr/local/etc/php/conf.d/docker-php-ext-zip.ini
#17 1.099 You can also run `php --ini` in a terminal to see which files are used by PHP in CLI mode.
#17 1.099 Alternatively, you can run Composer with `--ignore-platform-req=ext-pcntl` to temporarily ignore these required extensions.

```